### PR TITLE
[FIX] l10n_fr_vat_on_margin: print the line amount, keep the VAT hidden

### DIFF
--- a/l10n_fr_vat_on_margin/models/account_tax.py
+++ b/l10n_fr_vat_on_margin/models/account_tax.py
@@ -50,6 +50,40 @@ class AccountTax(models.Model):
     #         return tax_amount
     #     return 0.0
     #
+    def _filter_margin_tax_totals(self, tax_totals):
+        """Strip the margin VAT from a totals block about to be printed.
+
+        Art. 297 E of the CGI forbids showing the VAT on a document sold under
+        the margin scheme. Filtering the dict handed to the generic template
+        replaces patching account.document_tax_totals, which every report of
+        every module calls: the override made it read a variable only this
+        module ever set, so any other caller raised.
+
+        The on-screen widget is untouched; the seller still sees the VAT.
+
+        :param tax_totals: the dict produced by _prepare_tax_totals.
+        :return: a copy without the margin groups, or the dict itself when
+                 self carries no margin tax.
+        """
+        margin_group_ids = self.filtered('vat_on_margin').tax_group_id.ids
+        if not margin_group_ids:
+            return tax_totals
+
+        totals = dict(tax_totals)
+        groups_by_subtotal = {}
+        for subtotal_name, groups in (totals.get('groups_by_subtotal') or {}).items():
+            kept = [g for g in groups if g['tax_group_id'] not in margin_group_ids]
+            if kept:
+                groups_by_subtotal[subtotal_name] = kept
+        totals['groups_by_subtotal'] = groups_by_subtotal
+        # A subtotal left without any group would print an untaxed amount whose
+        # difference with the total gives the hidden VAT away.
+        totals['subtotals'] = [
+            s for s in (totals.get('subtotals') or [])
+            if groups_by_subtotal.get(s['name'])
+        ]
+        return totals
+
     def _convert_to_tax_base_line_dict(
             self, base_line,
             partner=None, currency=None, product=None, taxes=None, price_unit=None, price_unit_margin=None,

--- a/l10n_fr_vat_on_margin/views/account_report_views.xml
+++ b/l10n_fr_vat_on_margin/views/account_report_views.xml
@@ -1,43 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
+    <!-- Printed customer invoice under the margin scheme.
+
+         The VAT must not appear (art. 297 E CGI). What must NOT disappear is
+         the amount of each line: hiding the whole column left the printed
+         document without any figure per line, and the customer had to redo
+         the multiplication to check the invoice. -->
     <record id="report_invoice_document_inherit" model="ir.ui.view">
-        <field name="name">report.invoice.document.vat</field>
+        <field name="name">report.invoice.document.vat.on.margin</field>
         <field name="inherit_id" ref="account.report_invoice_document"/>
         <field name="arch" type="xml">
-            <xpath expr="//th[@name='th_subtotal']" position="attributes">
-                <attribute name="t-if">not o.fiscal_position_id.vat_on_margin</attribute>
-            </xpath>
             <xpath expr="//th[@name='th_taxes']" position="attributes">
-                <attribute name="t-if">not o.fiscal_position_id.vat_on_margin</attribute>
-            </xpath>
-            <xpath expr="//td[hasclass('o_price_total')]" position="attributes">
-                <attribute name="t-if">not o.fiscal_position_id.vat_on_margin</attribute>
+                <attribute name="t-if">not o.invoice_line_ids.tax_ids.filtered('vat_on_margin')</attribute>
             </xpath>
             <xpath expr="//td[@name='td_taxes']" position="attributes">
-                <attribute name="t-if">not o.fiscal_position_id.vat_on_margin</attribute>
+                <attribute name="t-if">not o.invoice_line_ids.tax_ids.filtered('vat_on_margin')</attribute>
             </xpath>
-            <t t-call="account.document_tax_totals" position="before">
-                <t t-set="vat_on_margin" t-value="o.fiscal_position_id.vat_on_margin"/>
-            </t>
 
+            <!-- The amount column stays. A margin line prints its all-in
+                 price: on a B2B database the native cell shows the untaxed
+                 amount, and next to the total that gives away the VAT, hence
+                 the margin and the purchase price. -->
+            <xpath expr="//td[hasclass('o_price_total')]/span[@t-field='line.price_subtotal']" position="attributes">
+                <attribute name="t-if">not line.line_concerned_by_margin</attribute>
+            </xpath>
+            <xpath expr="//td[hasclass('o_price_total')]/span[@t-field='line.price_total']" position="attributes">
+                <attribute name="t-if">not line.line_concerned_by_margin</attribute>
+            </xpath>
+            <xpath expr="//td[hasclass('o_price_total')]" position="inside">
+                <span t-if="line.line_concerned_by_margin" class="text-nowrap" t-field="line.price_total"/>
+            </xpath>
+
+            <!-- Hand the generic template a block without the margin VAT,
+                 rather than patching that template, which is shared by every
+                 report of every module. -->
+            <xpath expr="//t[@t-set='tax_totals']" position="attributes">
+                <attribute name="t-value">o.invoice_line_ids.tax_ids._filter_margin_tax_totals(o.tax_totals)</attribute>
+            </xpath>
         </field>
     </record>
-    <record id="document_tax_totals_inherit" model="ir.ui.view">
-        <field name="name">document.tax.totals.vat</field>
-        <field name="inherit_id" ref="account.document_tax_totals"/>
-        <field name="arch" type="xml">
-            <xpath expr='//t[@t-foreach="tax_totals[&#39;subtotals&#39;]"]' position="attributes">
-                <attribute name="t-if">not vat_on_margin</attribute>
-            </xpath>
-            <xpath expr='//t[@t-foreach="tax_totals[&#39;subtotals&#39;]"]' position="inside">
-                <t t-out="vat_on_margin"/>
-            </xpath>
-            <!--            <xpath expr="//t[contains(@t-if, 'formatted_rounding_amount')]" position="attributes">-->
-            <!--                <attribute name="t-if">'formatted_rounding_amount' in tax_totals and tax_totals['rounding_amount'] != 0-->
-            <!--                    or not vat_on_margin-->
-            <!--                </attribute>-->
-            <!--            </xpath>-->
-        </field>
-    </record>
-
 </odoo>

--- a/l10n_fr_vat_on_margin/views/purchase_order_views.xml
+++ b/l10n_fr_vat_on_margin/views/purchase_order_views.xml
@@ -1,27 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <!-- Printed purchase order, same treatment as the sale side. -->
     <record id="report_purchaseorder_document_inherit" model="ir.ui.view">
-        <field name="name">report.purchaseorder.document.vat</field>
+        <field name="name">report.purchaseorder.document.vat.on.margin</field>
         <field name="inherit_id" ref="purchase.report_purchaseorder_document"/>
         <field name="arch" type="xml">
-            <xpath expr="//th[@name='th_amount']" position="attributes">
-                <attribute name="t-if">not o.fiscal_position_id.vat_on_margin</attribute>
-            </xpath>
             <xpath expr="//th[@name='th_taxes']" position="attributes">
-                <attribute name="t-if">not o.fiscal_position_id.vat_on_margin</attribute>
-            </xpath>
-            <xpath expr="//span[@t-field='line.price_subtotal']/ancestor::td[1]" position="attributes">
-                <attribute name="t-if">not o.fiscal_position_id.vat_on_margin</attribute>
-            </xpath>
-            <xpath expr="//span[@t-field='line.price_subtotal']//ancestor::td" position="attributes">
-                <attribute name="t-if">not o.fiscal_position_id.vat_on_margin</attribute>
+                <attribute name="t-if">not o.order_line.taxes_id.filtered('vat_on_margin')</attribute>
             </xpath>
             <xpath expr="//td[@name='td_taxes']" position="attributes">
-                <attribute name="t-if">not o.fiscal_position_id.vat_on_margin</attribute>
+                <attribute name="t-if">not o.order_line.taxes_id.filtered('vat_on_margin')</attribute>
             </xpath>
-            <t t-call="account.document_tax_totals" position="before">
-                <t t-set="vat_on_margin" t-value="o.fiscal_position_id.vat_on_margin"/>
-            </t>
+
+            <xpath expr="//span[@t-field='line.price_subtotal']" position="attributes">
+                <attribute name="t-if">not line.taxes_id.filtered('vat_on_margin')</attribute>
+            </xpath>
+            <xpath expr="//span[@t-field='line.price_subtotal']/.." position="inside">
+                <span t-if="line.taxes_id.filtered('vat_on_margin')"
+                      t-field="line.price_total"
+                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+            </xpath>
+
+            <xpath expr="//t[@t-set='tax_totals']" position="attributes">
+                <attribute name="t-value">o.order_line.taxes_id._filter_margin_tax_totals(o.tax_totals)</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/l10n_fr_vat_on_margin/views/sale_order_views.xml
+++ b/l10n_fr_vat_on_margin/views/sale_order_views.xml
@@ -15,50 +15,60 @@
         </field>
     </record>
 
+    <!-- Printed quote. Same rules as the invoice: the margin VAT goes away,
+         the line amount stays. -->
     <record id="report_saleorder_document_inherit" model="ir.ui.view">
-        <field name="name">report.saleorder.document.vat</field>
+        <field name="name">report.saleorder.document.vat.on.margin</field>
         <field name="inherit_id" ref="sale.report_saleorder_document"/>
         <field name="arch" type="xml">
-            <xpath expr="//th[@name='th_subtotal']" position="attributes">
-                <attribute name="t-if">not doc.fiscal_position_id.vat_on_margin</attribute>
-            </xpath>
             <xpath expr="//th[@name='th_taxes']" position="attributes">
-                <attribute name="t-if">not doc.fiscal_position_id.vat_on_margin</attribute>
-            </xpath>
-            <xpath expr="//td[hasclass('o_price_total')]" position="attributes">
-                <attribute name="t-if">not doc.fiscal_position_id.vat_on_margin</attribute>
+                <attribute name="t-if">not doc.order_line.tax_id.filtered('vat_on_margin')</attribute>
             </xpath>
             <xpath expr="//td[@name='td_taxes']" position="attributes">
-                <attribute name="t-if">not doc.fiscal_position_id.vat_on_margin</attribute>
+                <attribute name="t-if">not doc.order_line.tax_id.filtered('vat_on_margin')</attribute>
             </xpath>
-            <t t-call="account.document_tax_totals" position="before">
-                <t t-set="vat_on_margin" t-value="doc.fiscal_position_id.vat_on_margin"/>
-            </t>
+
+            <xpath expr="//td[@name='td_subtotal']/span[@t-field='line.price_subtotal']" position="attributes">
+                <attribute name="t-if">not line.line_concerned_by_margin</attribute>
+            </xpath>
+            <xpath expr="//td[@name='td_subtotal']/span[@t-field='line.price_total']" position="attributes">
+                <attribute name="t-if">not line.line_concerned_by_margin</attribute>
+            </xpath>
+            <xpath expr="//td[@name='td_subtotal']" position="inside">
+                <span t-if="line.line_concerned_by_margin" class="text-nowrap" t-field="line.price_total"/>
+            </xpath>
+
+            <xpath expr="//t[@t-set='tax_totals']" position="attributes">
+                <attribute name="t-value">doc.order_line.tax_id._filter_margin_tax_totals(doc.tax_totals)</attribute>
+            </xpath>
         </field>
     </record>
 
+    <!-- Customer portal view of the quote, aligned on the printed one. -->
     <record id="sale_order_portal_content_inherit" model="ir.ui.view">
-        <field name="name">report.saleorder.portal.content.vat</field>
+        <field name="name">sale.order.portal.content.vat.on.margin</field>
         <field name="inherit_id" ref="sale.sale_order_portal_content"/>
         <field name="arch" type="xml">
-            <th t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"
-                position="attributes">
-                <attribute name="t-if">not sale_order.fiscal_position_id.vat_on_margin</attribute>
-            </th>
-            <xpath expr="//span[@groups='account.group_show_line_subtotals_tax_excluded']/ancestor::th[1]"
-                   position="attributes">
-                <attribute name="t-if">not sale_order.fiscal_position_id.vat_on_margin</attribute>
+            <xpath expr="//span[hasclass('oe_order_line_price_subtotal')]" position="attributes">
+                <attribute name="t-if">not line.line_concerned_by_margin</attribute>
             </xpath>
-            <td t-if="not line.is_downpayment" class="text-end" position="attributes">
-                <attribute name="t-if">not sale_order.fiscal_position_id.vat_on_margin</attribute>
-            </td>
-            <td t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"
-                position="attributes">
-                <attribute name="t-if">not sale_order.fiscal_position_id.vat_on_margin</attribute>
-            </td>
-            <t t-call="sale.sale_order_portal_content_totals_table" position="before">
-                <t t-set="vat_on_margin" t-value="sale_order.fiscal_position_id.vat_on_margin"/>
-            </t>
+            <xpath expr="//span[hasclass('oe_order_line_price_total')]" position="attributes">
+                <attribute name="t-if">not line.line_concerned_by_margin</attribute>
+            </xpath>
+            <xpath expr="//span[hasclass('oe_order_line_price_subtotal')]/.." position="inside">
+                <span t-if="line.line_concerned_by_margin"
+                      class="oe_order_line_price_total" t-field="line.price_total"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="sale_order_portal_content_totals_table_inherit" model="ir.ui.view">
+        <field name="name">sale.order.portal.totals.vat.on.margin</field>
+        <field name="inherit_id" ref="sale.sale_order_portal_content_totals_table"/>
+        <field name="arch" type="xml">
+            <xpath expr="//t[@t-set='tax_totals']" position="attributes">
+                <attribute name="t-value">sale_order.order_line.tax_id._filter_margin_tax_totals(sale_order.tax_totals)</attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
The t-if guarding the margin scheme was put on the amount cell itself, so selecting the margin fiscal position removed the line total from the printed quote, order and invoice. That is what the customer reported: visible on screen, gone on paper. It also overwrote the native "not line.is_downpayment" guard on that cell.

The column comes back and a margin line prints its all-in price. The untaxed amount would not do: this database displays subtotals B2B, so the cell would read 233.33 next to a total of 240.00, and the difference is the VAT, hence the margin and the purchase price.

account.document_tax_totals is no longer patched. That template is shared by every report of every module, and the override made it read a variable only this module ever set, so any other caller raised. It also printed the raw boolean into the totals block. The totals dict is filtered before being handed over instead, which leaves the template alone; the on-screen widget keeps the full breakdown for the seller.

Everything now keys on the tax rather than the fiscal position. Keying the columns on one and the totals on the other printed a document naming the tax while hiding its amount, and a forgotten fiscal position silently produced a non-compliant document.